### PR TITLE
Fixes bug in SET_POSTS_COMMENTS case in reducer

### DIFF
--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -56,7 +56,6 @@ export const reducer = (state = initialState, action) => {
       };
 
     case 'SET_POSTS_COMMENTS':
-      console.log(action.payload)
       return {
         ...state,
         currentPostComments: [...state.currentPostComments, action.payload]

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -56,12 +56,10 @@ export const reducer = (state = initialState, action) => {
       };
 
     case 'SET_POSTS_COMMENTS':
+      console.log(action.payload)
       return {
         ...state,
-        currentPost: {
-          ...state.currentPost,
-          comments: [action.payload, ...state.currentPost.comments],
-        },
+        currentPostComments: [...state.currentPostComments, action.payload]
       };
 
     case 'SET_USERS_LIKED_COMMENTS':


### PR DESCRIPTION
# Description

The comments were being posted to the backend, however weren't being shown on the front end after successfully creating a comment. This was due to the "SET_POSTS_COMMENTS" case in the reducer updating the wrong piece of state. I've updated it to change the correct piece of state.