### PR TITLE
Rooms persistence

### DIFF
--- a/src/components/dashboard/rooms.js
+++ b/src/components/dashboard/rooms.js
@@ -10,21 +10,23 @@ const Rooms = (props) => {
 
   useEffect(() => {
     props.fetchRooms();
+    if (localStorage.getItem("currentRoom")) {
+      props.setCurrentRoom(JSON.parse(localStorage.getItem("currentRoom")))
+    }
   }, []);
 
   useEffect(() => {
     const params = new URLSearchParams()
     if (query) {
       params.append("room", query)
-    } else {
-      params.delete("room")
-    }
-    history.push({search: params.toString()})
+      history.push({search: params.toString()})
+    } 
   }, [query, history])
 
   const handleClick = (room) => {
     setQuery(room.id)
     props.setCurrentRoom(room)
+    localStorage.setItem("currentRoom", JSON.stringify(room))
   }
 
   const handleAll = () => {


### PR DESCRIPTION
# LAN-B FE PR
Trello Card URL :  https://trello.com/c/ASD1YnFG/10-as-a-user-i-am-able-to-to-view-and-navigate-through-the-rooms-depending-on-topic

# Description of changes: 
Changes params based useEffect to keep room query persistent in rooms component. Sets up local storage/recall for currentRoom.

## How was it tested? 
reloaded pages with persistence of url, currentRoom state, and UI. Created posts, where UI is pushed back to room view on.

## PR Checklist: 

✅  Code follows project guidelines
❌ Self reviewed / peer reviewed 
✅  New warnings fixed
✅  Atomic commits 
✅  Removed debug code
✅  No merge conflicts 